### PR TITLE
feat: Add simple Actix-web server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+actix-web = "4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,16 @@
-fn main() {
-    println!("Hello, world!");
+use actix_web::{get, App, HttpResponse, HttpServer, Responder};
+
+#[get("/")]
+async fn hello() -> impl Responder {
+    HttpResponse::Ok().body("Hello, World!")
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new().service(hello)
+    })
+    .bind(("127.0.0.1", 8080))?
+    .run()
+    .await
 }


### PR DESCRIPTION
This commit introduces a basic web server using Actix-web. It listens on 127.0.0.1:8080 and serves a "Hello, World!" message at the root endpoint (/).

Automated tests were not included due to limitations with the Rust version (1.75.0) in the current environment, which caused compatibility issues with actix-web's testing utilities and dependencies.